### PR TITLE
Add missing quotes

### DIFF
--- a/build-aux/ltmain.in
+++ b/build-aux/ltmain.in
@@ -3284,7 +3284,7 @@ func_extract_archives ()
 	    $RM -rf unfat-$$
 	    cd "$darwin_orig_dir"
 	  else
-	    cd $darwin_orig_dir
+	    cd "$darwin_orig_dir"
 	    func_extract_an_archive "$my_xdir" "$my_xabs"
 	  fi # $darwin_arches
 	} # !$opt_dry_run


### PR DESCRIPTION
I don't know how to do a proper bug report (probably at https://savannah.gnu.org/projects/libtool/?), but I hope somebody finds this and somehow propagates it to the right channels ...

I found this problem while reading https://github.com/SoundScapeRenderer/ssr/pull/293.