### PR TITLE
Fix Wstrict-prototypes warnings

### DIFF
--- a/build-aux/ltmain.in
+++ b/build-aux/ltmain.in
@@ -7320,7 +7320,7 @@ func_mode_link ()
 	  # whether they linked in statically or dynamically with ldd.
 	  $opt_dry_run || $RM conftest.c
 	  cat > conftest.c <<EOF
-	  int main() { return 0; }
+	  int main(void) { return 0; }
 EOF
 	  $opt_dry_run || $RM conftest
 	  if $LTCC $LTCFLAGS -o conftest conftest.c $deplibs; then

--- a/m4/libtool.m4
+++ b/m4/libtool.m4
@@ -1048,7 +1048,7 @@ _LT_EOF
       echo "$RANLIB libconftest.a" >&AS_MESSAGE_LOG_FD
       $RANLIB libconftest.a 2>&AS_MESSAGE_LOG_FD
       cat > conftest.c << _LT_EOF
-int main() { return 0;}
+int main(void) { return 0;}
 _LT_EOF
       echo "$LTCC $LTCFLAGS $LDFLAGS -o conftest conftest.c -Wl,-force_load,./libconftest.a" >&AS_MESSAGE_LOG_FD
       $LTCC $LTCFLAGS $LDFLAGS -o conftest conftest.c -Wl,-force_load,./libconftest.a 2>conftest.err
@@ -1879,11 +1879,11 @@ else
 /* When -fvisibility=hidden is used, assume the code has been annotated
    correspondingly for the symbols needed.  */
 #if defined __GNUC__ && (((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3))
-int fnord () __attribute__((visibility("default")));
+int fnord (void) __attribute__((visibility("default")));
 #endif
 
-int fnord () { return 42; }
-int main ()
+int fnord (void) { return 42; }
+int main (void)
 {
   void *self = dlopen (0, LT_DLGLOBAL|LT_DLLAZY_OR_NOW);
   int status = $lt_dlunknown;
@@ -4061,7 +4061,7 @@ void nm_test_func(void){}
 #ifdef __cplusplus
 }
 #endif
-int main(){nm_test_var='a';nm_test_func();return(0);}
+int main(void){nm_test_var='a';nm_test_func();return(0);}
 _LT_EOF
 
   if AC_TRY_EVAL(ac_compile); then
@@ -6233,7 +6233,7 @@ _LT_TAGVAR(objext, $1)=$objext
 lt_simple_compile_test_code="int some_variable = 0;"
 
 # Code to be used in simple link tests
-lt_simple_link_test_code='int main(){return(0);}'
+lt_simple_link_test_code='int main(void){return(0);}'
 
 _LT_TAG_COMPILER
 # Save the default compiler, since it gets overwritten when the other

--- a/m4/ltdl.m4
+++ b/m4/ltdl.m4
@@ -758,7 +758,7 @@ AC_CACHE_CHECK([for _ prefix in compiled symbols],
   [lt_cv_sys_symbol_underscore=no
   cat > conftest.$ac_ext <<_LT_EOF
 void nm_test_func(){}
-int main(){nm_test_func;return 0;}
+int main(void){nm_test_func;return 0;}
 _LT_EOF
   if AC_TRY_EVAL(ac_compile); then
     # Now try to grab the symbols.
@@ -862,7 +862,7 @@ _LT_EOF
 #    define RTLD_NOW 0
 #  endif
 #endif
-int main () {
+int main (void) {
   void *handle = dlopen ("`pwd`/$libname$libltdl_cv_shlibext", RTLD_GLOBAL|RTLD_NOW);
   int status = $libltdl_dlunknown;
   if (handle) {


### PR DESCRIPTION
This changes the C function prototypes to use void where needed. When building with CFLAGS=-Werror=strict-prototypes or similar, the libtool's tests can cause false reports and errors in the log files:

    error: function declaration isn't a prototype

Related to https://github.com/php/php-src/pull/13732

Edit: patch sent also to the [libtool-patches mailing list](https://lists.gnu.org/archive/html/libtool-patches/2024-03/msg00002.html).